### PR TITLE
Update exampleConfig.json

### DIFF
--- a/exampleConfig.json
+++ b/exampleConfig.json
@@ -6,7 +6,7 @@
     "type": "panasonicHttpCamera",
     "properties": {
         "control": {
-            "type": "http",
+            "method": "http",
             "tcpSshProperties": {
                 "address": "192.168.10.21",
                 "port": 0


### PR DESCRIPTION
Example config causes null ref exception at boot due to not having "method" defined and the warning time must be less than the error time.