### PR TITLE
Feature/handle busy no retry

### DIFF
--- a/PanasonicCameraEpi/HttpCommandQueue.cs
+++ b/PanasonicCameraEpi/HttpCommandQueue.cs
@@ -8,14 +8,27 @@ namespace PanasonicCameraEpi
 {
     public class HttpCommandQueue : CommandQueue
     {
+        private volatile bool _cameraBusy;
+
+        public void WireBusy(PanasonicResponseHandler rh)
+        {
+            if (rh == null) return;
+            rh.BusyChanged += delegate(object s, PanasonicResponseHandler.BusyChangedEventArgs e)
+            {
+                _cameraBusy = e.IsBusy;
+            };
+        }
+
         public event EventHandler<GenericHttpClientEventArgs> ResponseReceived;
-        private int _pacing = 130; 
+
+        // Panasonic spec tolerates >=40ms; 130ms is conservative and stable
+        private int _pacing = 130;
 
         public HttpCommandQueue(IBasicCommunication coms)
             : base(coms)
         {
-
         }
+
         public HttpCommandQueue(IBasicCommunication coms, int pacing)
             : base(coms)
         {
@@ -28,7 +41,7 @@ namespace PanasonicCameraEpi
             if (client == null)
                 throw new NullReferenceException("client");
 
-            while (true)
+            while (true) // keep the worker alive
             {
                 string path = null;
 
@@ -36,35 +49,66 @@ namespace PanasonicCameraEpi
                 {
                     path = _cmdQueue.Dequeue();
                     if (path == null)
-                        break;
+                    {
+                        Thread.Sleep(20);
+                        continue;
+                    }
                 }
+
                 if (path != null)
                 {
-                    if(string.IsNullOrEmpty(client.Client.HostName))
+                    if (string.IsNullOrEmpty(client.Client.HostName))
                     {
-                        Debug.Console(0, client, "Panasonic camera hostname not valid");
-                        return null;
+                        Debug.Console(0, "Panasonic camera hostname not valid");
+                        Thread.Sleep(1000); // don't kill the thread
+                        continue;
                     }
+
                     try
                     {
+                        // Back off while camera is busy (e.g., RP150 is moving it)
+                        if (_cameraBusy)
+                        {
+                            var waited = 0;
+                            while (_cameraBusy && waited < 2000) // up to 2s
+                            {
+                                Thread.Sleep(50);
+                                waited += 50;
+                            }
+
+                            // Still busy? Requeue and try later
+                            if (_cameraBusy)
+                            {
+                                _cmdQueue.Enqueue(path);
+                                // optional: signal wait handle here if your base queue expects it
+                                continue;
+                            }
+                        }
+
                         var request = new HttpClientRequest();
-                        var url = String.Format("http://{0}/{1}", client.Client.HostName, path);
+                        var url = string.Format("http://{0}/{1}", client.Client.HostName, path);
                         request.Url.Parse(url);
 
-                        Debug.Console(1, client, "Dispatching request: {0}", request.Url.PathAndParams);
+                        Debug.Console(1, "Dispatching request: {0}", request.Url.PathAndParams);
 
                         client.Client.DispatchAsync(request, OnResponseReceived);
-                        Thread.Sleep(_pacing); //command gap of 130 recommended by documentation
+
+                        // Panasonic pacing
+                        Thread.Sleep(_pacing);
                     }
                     catch (Exception ex)
                     {
-                        Debug.Console(1, client, "Caught an exception in the CmdProcessor {0}\r{1}\r{2}", ex.Message, ex.InnerException, ex.StackTrace);
+                        Debug.Console(1, "Caught an exception in the CmdProcessor {0}\r{1}\r{2}",
+                            ex.Message, ex.InnerException, ex.StackTrace);
+                        Thread.Sleep(100); // keep thread alive
                     }
                 }
-                else _wh.Wait();
+                else
+                {
+                    // Wait until someone enqueues
+                    _wh.Wait();
+                }
             }
-
-            return null;
         }
 
         private void OnResponseReceived(HttpClientResponse response, HTTP_CALLBACK_ERROR error)
@@ -72,22 +116,26 @@ namespace PanasonicCameraEpi
             try
             {
                 Debug.Console(1, this, "Panasonic camera client response code: {0}", response.Code);
+
                 if (error != HTTP_CALLBACK_ERROR.COMPLETED)
                 {
                     Debug.Console(1, this, "Panasonic camera client callback error: {0}", error);
                     return;
                 }
+
                 if (response.Code < 200 || response.Code >= 300)
                 {
                     Debug.Console(1, this, "Panasonic camera client callback http code error: {0}", response.Code);
                     return;
                 }
 
-                if (ResponseReceived == null)
+                var handler = ResponseReceived;
+                if (handler == null)
                     return;
 
-                ResponseReceived.Invoke(this, new GenericHttpClientEventArgs(response.ContentString, response.ResponseUrl, HTTP_CALLBACK_ERROR.COMPLETED));
-
+                // Essentials GenericHttpClientEventArgs signature in your repo:
+                // (string responseText, string requestPath, HTTP_CALLBACK_ERROR error)
+                handler(this, new GenericHttpClientEventArgs(response.ContentString, response.ResponseUrl, HTTP_CALLBACK_ERROR.COMPLETED));
             }
             catch (Exception ex)
             {

--- a/PanasonicCameraEpi/HttpCommandQueue.cs
+++ b/PanasonicCameraEpi/HttpCommandQueue.cs
@@ -66,23 +66,12 @@ namespace PanasonicCameraEpi
 
                     try
                     {
-                        // Back off while camera is busy (e.g., RP150 is moving it)
+                        // Skip command while camera is busy (do not send or re-enqueue)
                         if (_cameraBusy)
                         {
-                            var waited = 0;
-                            while (_cameraBusy && waited < 2000) // up to 2s
-                            {
-                                Thread.Sleep(50);
-                                waited += 50;
-                            }
-
-                            // Still busy? Requeue and try later
-                            if (_cameraBusy)
-                            {
-                                _cmdQueue.Enqueue(path);
-                                // optional: signal wait handle here if your base queue expects it
-                                continue;
-                            }
+                            Debug.Console(1, "Skipped command while device busy: {0}", path);
+                            // do NOT send, do NOT re-enqueue
+                            continue;
                         }
 
                         var request = new HttpClientRequest();

--- a/PanasonicCameraEpi/HttpCommandQueue.cs
+++ b/PanasonicCameraEpi/HttpCommandQueue.cs
@@ -133,8 +133,6 @@ namespace PanasonicCameraEpi
                 if (handler == null)
                     return;
 
-                // Essentials GenericHttpClientEventArgs signature in your repo:
-                // (string responseText, string requestPath, HTTP_CALLBACK_ERROR error)
                 handler(this, new GenericHttpClientEventArgs(response.ContentString, response.ResponseUrl, HTTP_CALLBACK_ERROR.COMPLETED));
             }
             catch (Exception ex)

--- a/PanasonicCameraEpi/PanasonicCamera.cs
+++ b/PanasonicCameraEpi/PanasonicCamera.cs
@@ -11,7 +11,6 @@ using PepperDash.Essentials.Devices.Common.Cameras;
 using PepperDash.Core;
 using Crestron.SimplSharp;
 
-
 namespace PanasonicCameraEpi
 {
     public class PanasonicCamera : ReconfigurableDevice, IBridgeAdvanced, IHasCameraPtzControl, IHasCameraOff, ICommunicationMonitor, IRoutingSource
@@ -26,25 +25,15 @@ namespace PanasonicCameraEpi
         public Dictionary<uint, StringFeedback> PresetNamesFeedbacks { get; private set; }
         public IntFeedback NumberOfPresetsFeedback { get; private set; }
         public StringFeedback NameFeedback { get; private set; }
-        //public StringFeedback ComsFeedback { get; set; }
-        public BoolFeedback IsOnlineFeedback { get { return _monitor.IsOnlineFeedback; } }		
+        public BoolFeedback IsOnlineFeedback { get { return _monitor.IsOnlineFeedback; } }
         public IntFeedback PanSpeedFeedback { get; private set; }
         public IntFeedback ZoomSpeedFeedback { get; private set; }
         public IntFeedback TiltSpeedFeedback { get; private set; }
         public BoolFeedback PresetSavedFeedback { get; private set; }
         public bool PresetSavedBool
         {
-            get
-            {
-                return _PresetSavedBool;
-            }
-            set
-            {
-                _PresetSavedBool = value;
-                PresetSavedFeedback.FireUpdate();
-            }
-
-               
+            get { return _PresetSavedBool; }
+            set { _PresetSavedBool = value; PresetSavedFeedback.FireUpdate(); }
         }
         private bool _PresetSavedBool { get; set; }
 
@@ -53,9 +42,9 @@ namespace PanasonicCameraEpi
         {
             OutputPorts = new RoutingPortCollection<RoutingOutputPort>();
 
-			var cameraConfig = PanasonicCameraPropsConfig.FromDeviceConfig(config);
+            var cameraConfig = PanasonicCameraPropsConfig.FromDeviceConfig(config);
 
-			_responseHandler = new PanasonicResponseHandler();
+            _responseHandler = new PanasonicResponseHandler();
 
             if (cameraConfig.CommunicationMonitor == null)
                 cameraConfig.CommunicationMonitor = new CommunicationMonitorConfig
@@ -66,73 +55,67 @@ namespace PanasonicCameraEpi
                     PollString = "cgi-bin/aw_ptz?cmd=%23O&res=1"
                 };
 
-            var tempClient = comms as GenericHttpClient;	
-            if(tempClient == null) 
+            var tempClient = comms as GenericHttpClient;
+            if (tempClient == null)
             {
                 _monitor = new GenericCommunicationMonitor(this, comms, cameraConfig.CommunicationMonitor);
-                comms.TextReceived += _responseHandler.HandleResponseReceeved;
-                    throw new NotImplementedException("Need to create a command queue for serial");
-			}
+                comms.TextReceived += _responseHandler.HandleResponseReceived;
+                throw new NotImplementedException("Need to create a command queue for serial");
+            }
             _monitor = new PanasonicHttpCameraMonitor(this, tempClient, cameraConfig.CommunicationMonitor);
-            HttpCommandQueue queue; 
-            if (cameraConfig.Pacing > 0)
-            {
-                 queue = new HttpCommandQueue(comms, cameraConfig.Pacing);
-            }
-            else
-            {
-                 queue = new HttpCommandQueue(comms);
-            }
+
+            // --- queue setup (fixed variable name and wiring) ---
+            var queue = (cameraConfig.Pacing > 0)
+                ? new HttpCommandQueue(comms, cameraConfig.Pacing)
+                : new HttpCommandQueue(comms);
+
+            // Busy/backoff wiring first
+            queue.WireBusy(_responseHandler);
+
+            // Route HTTP responses to the handler
             queue.ResponseReceived += _responseHandler.HandleResponseReceived;
+
             _queue = queue;
 
             _cmd = new PanasonicCmdBuilder(12, 25, 12, cameraConfig.HomeCommand, cameraConfig.PrivacyCommand);
             _presets = cameraConfig.Presets.ToDictionary(x => (uint)x.Id);
 
             AddPostActivationAction(() =>
-                {
-                    if (cameraConfig.ZoomSpeed == 0)
-                        return;
-
-                    ZoomSpeed = cameraConfig.ZoomSpeed;
-                });
-
-            AddPostActivationAction(() =>
             {
-                if (cameraConfig.TiltSpeed == 0)
-                    return;
-
-                TiltSpeed = cameraConfig.TiltSpeed;
+                if (cameraConfig.ZoomSpeed != 0) ZoomSpeed = cameraConfig.ZoomSpeed;
             });
 
             AddPostActivationAction(() =>
             {
-                if (cameraConfig.PanSpeed == 0)
-                    return;
+                if (cameraConfig.TiltSpeed != 0) TiltSpeed = cameraConfig.TiltSpeed;
+            });
 
-                PanSpeed = cameraConfig.PanSpeed;
+            AddPostActivationAction(() =>
+            {
+                if (cameraConfig.PanSpeed != 0) PanSpeed = cameraConfig.PanSpeed;
             });
         }
+
         public override bool CustomActivate()
         {
             SetupFeedbacks();
             _responseHandler.CameraPoweredOn += (sender, args) =>
-                {
-                    IsPoweredOn = true;
-                    CameraIsOffFeedback.FireUpdate();
-                };
+            {
+                IsPoweredOn = true;
+                CameraIsOffFeedback.FireUpdate();
+            };
 
             _responseHandler.CameraPoweredOff += (sender, args) =>
-                {
-                    IsPoweredOn = false;
-                    CameraIsOffFeedback.FireUpdate();
-                };
+            {
+                IsPoweredOn = false;
+                CameraIsOffFeedback.FireUpdate();
+            };
 
             _monitor.StatusChange += HandleMonitorStatusChange;
             _monitor.Start();
 
             return true;
-        }        
+        }
 
         private void HandleMonitorStatusChange(object sender, MonitorStatusChangeEventArgs e)
         {
@@ -150,7 +133,7 @@ namespace PanasonicCameraEpi
                 if (_presets.ContainsKey(index))
                     continue;
 
-                _presets.Add(index, new PanasonicCameraPreset {Id = (int) index, Name = String.Empty});
+                _presets.Add(index, new PanasonicCameraPreset { Id = (int)index, Name = String.Empty });
             }
 
             NumberOfPresetsFeedback = new IntFeedback(() => _presets.Values.Count(x => !String.IsNullOrEmpty(x.Name)));
@@ -159,7 +142,7 @@ namespace PanasonicCameraEpi
             PanSpeedFeedback = new IntFeedback(() => PanSpeed);
             TiltSpeedFeedback = new IntFeedback(() => TiltSpeed);
             ZoomSpeedFeedback = new IntFeedback(() => ZoomSpeed);
-            PresetSavedFeedback = new BoolFeedback(() => PresetSavedBool); 
+            PresetSavedFeedback = new BoolFeedback(() => PresetSavedBool);
 
             PanSpeedFeedback.FireUpdate();
             TiltSpeedFeedback.FireUpdate();
@@ -171,124 +154,54 @@ namespace PanasonicCameraEpi
                 feedback.Value.FireUpdate();
 
             CameraIsOffFeedback = new BoolFeedback(() => !IsPoweredOn);
-            CameraIsOffFeedback.FireUpdate(); 
+            CameraIsOffFeedback.FireUpdate();
         }
 
         public int PanSpeed
         {
             get { return _cmd.PanSpeed; }
-            set 
-            { 
-                _cmd.PanSpeed = value;
-                PanSpeedFeedback.FireUpdate();
-            }
+            set { _cmd.PanSpeed = value; PanSpeedFeedback.FireUpdate(); }
         }
 
-        public int ZoomSpeed 
+        public int ZoomSpeed
         {
             get { return _cmd.ZoomSpeed; }
-            set 
-            { 
-                _cmd.ZoomSpeed = value;
-                ZoomSpeedFeedback.FireUpdate();
-            }
+            set { _cmd.ZoomSpeed = value; ZoomSpeedFeedback.FireUpdate(); }
         }
 
         public int TiltSpeed
         {
             get { return _cmd.TiltSpeed; }
-            set 
-            { 
-                _cmd.TiltSpeed = value;
-                TiltSpeedFeedback.FireUpdate();
-            }
+            set { _cmd.TiltSpeed = value; TiltSpeedFeedback.FireUpdate(); }
         }
 
         #region IHasCameraPtzControl Members
-
-        public void PositionHome()
-        {
-            _queue.EnqueueCmd(_cmd.HomeCommand);
-        }
-
-        public void PositionPrivacy()
-        {
-            _queue.EnqueueCmd(_cmd.PrivacyCommand);
-        }
-
+        public void PositionHome() { _queue.EnqueueCmd(_cmd.HomeCommand); }
+        public void PositionPrivacy() { _queue.EnqueueCmd(_cmd.PrivacyCommand); }
         #endregion
 
         #region IHasCameraPanControl Members
-
-        public void PanLeft()
-        {
-            _queue.EnqueueCmd(_cmd.PanLeftCommand);
-        }
-
-        public void PanRight()
-        {
-            _queue.EnqueueCmd(_cmd.PanRightCommand);
-        }
-
-        public void PanStop()
-        {
-            _queue.EnqueueCmd(_cmd.PanStopCommand);
-        }
-
+        public void PanLeft() { _queue.EnqueueCmd(_cmd.PanLeftCommand); }
+        public void PanRight() { _queue.EnqueueCmd(_cmd.PanRightCommand); }
+        public void PanStop() { _queue.EnqueueCmd(_cmd.PanStopCommand); }
         #endregion
 
         #region IHasCameraTiltControl Members
-
-        public void TiltDown()
-        {
-            _queue.EnqueueCmd(_cmd.TiltDownCommand);			
-        }
-
-        public void TiltUp()
-        {
-            _queue.EnqueueCmd(_cmd.TiltUpCommand);
-        }
-
-        public void TiltStop()
-        {
-            _queue.EnqueueCmd(_cmd.TiltStopCommand);
-        }    
-
+        public void TiltDown() { _queue.EnqueueCmd(_cmd.TiltDownCommand); }
+        public void TiltUp() { _queue.EnqueueCmd(_cmd.TiltUpCommand); }
+        public void TiltStop() { _queue.EnqueueCmd(_cmd.TiltStopCommand); }
         #endregion
 
         #region IHasCameraOff Members
-
         public BoolFeedback CameraIsOffFeedback { get; private set; }
-
-        public void CameraOn()
-        {
-            _queue.EnqueueCmd(_cmd.PowerOnCommand);
-        }
-
-        public void CameraOff()
-        {
-            _queue.EnqueueCmd(_cmd.PowerOffCommand);
-        }
-
+        public void CameraOn() { _queue.EnqueueCmd(_cmd.PowerOnCommand); }
+        public void CameraOff() { _queue.EnqueueCmd(_cmd.PowerOffCommand); }
         #endregion
 
         #region IHasCameraZoomControl Members
-
-        public void ZoomIn()
-        {
-            _queue.EnqueueCmd(_cmd.ZoomInCommand);
-        }
-
-        public void ZoomOut()
-        {
-            _queue.EnqueueCmd(_cmd.ZoomOutCommand);		
-        }
-
-        public void ZoomStop()
-        {
-            _queue.EnqueueCmd(_cmd.ZoomStopCommand);
-        }
-
+        public void ZoomIn() { _queue.EnqueueCmd(_cmd.ZoomInCommand); }
+        public void ZoomOut() { _queue.EnqueueCmd(_cmd.ZoomOutCommand); }
+        public void ZoomStop() { _queue.EnqueueCmd(_cmd.ZoomStopCommand); }
         #endregion
 
         public void SendCustomCommand(string cmd)
@@ -301,46 +214,45 @@ namespace PanasonicCameraEpi
             if (!IsPoweredOn)
                 _queue.EnqueueCmd(_cmd.PowerOnCommand);
 
-            _queue.EnqueueCmd(_cmd.PresetRecallCommand(preset));	        
+            _queue.EnqueueCmd(_cmd.PresetRecallCommand(preset));
         }
 
         public void SavePreset(int preset)
         {
             _queue.EnqueueCmd(_cmd.PresetSaveCommand(preset));
             PresetSavedBool = true;
-            new CTimer( (o) => PresetSavedBool = false, 5000);
+            new CTimer((o) => PresetSavedBool = false, 5000);
         }
 
-		/// <summary>
-		/// Sets the IP address used by the plugin 
-		/// </summary>
+        /// <summary>
+        /// Sets the IP address used by the plugin 
+        /// </summary>
         /// <param name="address">string</param>
-		public void SetIpAddress(string address)
-		{
-			try
-			{
-			    if (!(address.Length > 2 & Config.Properties["control"]["tcpSshProperties"]["address"].ToString() != address))
-			        return;
-			    Debug.Console(2, this, "Changing IPAddress: {0}", address);
+        public void SetIpAddress(string address)
+        {
+            try
+            {
+                if (!(address.Length > 2 & Config.Properties["control"]["tcpSshProperties"]["address"].ToString() != address))
+                    return;
+                Debug.Console(2, this, "Changing IPAddress: {0}", address);
 
-			    Config.Properties["control"]["tcpSshProperties"]["address"] = address;
-			    Debug.Console(2, this, "{0}", Config.Properties.ToString());
-			    SetConfig(Config);
-			    var tempClient = DeviceManager.GetDeviceForKey(string.Format("{0}-httpClient", Key)) as GenericHttpClient;
-			    if (tempClient == null)
-			    {
-			        throw new Exception("Error - No Valid TCP Client!");
-			    }
-			    tempClient.Client.HostName = address;
-			}
-			catch (Exception e)
-			{
-				if (Debug.Level == 2)
-					Debug.Console(2, this, "Error SetIpAddress: '{0}'", e);
-			}
-		}
+                Config.Properties["control"]["tcpSshProperties"]["address"] = address;
+                Debug.Console(2, this, "{0}", Config.Properties.ToString());
+                SetConfig(Config);
+                var tempClient = DeviceManager.GetDeviceForKey(string.Format("{0}-httpClient", Key)) as GenericHttpClient;
+                if (tempClient == null)
+                {
+                    throw new Exception("Error - No Valid TCP Client!");
+                }
+                tempClient.Client.HostName = address;
+            }
+            catch (Exception e)
+            {
+                if (Debug.Level == 2)
+                    Debug.Console(2, this, "Error SetIpAddress: '{0}'", e);
+            }
+        }
 
-	
         public void UpdatePresetName(int presetId, string name)
         {
             if (String.IsNullOrEmpty(name))
@@ -354,7 +266,7 @@ namespace PanasonicCameraEpi
 
             foreach (var feedback in PresetNamesFeedbacks)
                 feedback.Value.FireUpdate();
-            
+
             NumberOfPresetsFeedback.FireUpdate();
 
             var props = PanasonicCameraPropsConfig.FromDeviceConfig(Config);
@@ -365,44 +277,28 @@ namespace PanasonicCameraEpi
         }
 
         #region Overrides of EssentialsBridgeableDevice
-
-        /// <summary>
-        /// Links the plugin device to the EISC bridge
-        /// </summary>
-        /// <param name="trilist"></param>
-        /// <param name="joinStart"></param>
-        /// <param name="joinMapKey"></param>
-        /// <param name="bridge"></param>        
         public void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
         {
             var joinMap = new PanasonicCameraBridgeJoinMap(joinStart);
 
-            // This adds the join map to the collection on the bridge
             if (bridge != null)
-            {
                 bridge.AddJoinMap(Key, joinMap);
-            }
 
             var customJoins = JoinMapHelper.TryGetJoinMapAdvancedForDevice(joinMapKey);
-
             if (customJoins != null)
-            {
                 joinMap.SetCustomJoinData(customJoins);
-            }
 
             Debug.Console(1, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
             Debug.Console(0, "Linking to Bridge Type {0}", GetType().Name);
 
-            // links to bridge
             trilist.SetString(joinMap.DeviceName.JoinNumber, Name);
             trilist.SetStringSigAction(joinMap.DeviceComs.JoinNumber, SendCustomCommand);
-            
+
             NameFeedback.LinkInputSig(trilist.StringInput[joinMap.DeviceName.JoinNumber]);
-            
             NumberOfPresetsFeedback.LinkInputSig(trilist.UShortInput[joinMap.NumberOfPresets.JoinNumber]);
 
             PresetSavedFeedback.LinkInputSig(trilist.BooleanInput[joinMap.PresetSavedFeedback.JoinNumber]);
-            
+
             CameraIsOffFeedback.LinkInputSig(trilist.BooleanInput[joinMap.PowerOff.JoinNumber]);
             CameraIsOffFeedback.LinkComplementInputSig(trilist.BooleanInput[joinMap.PowerOn.JoinNumber]);
 
@@ -412,41 +308,12 @@ namespace PanasonicCameraEpi
             TiltSpeedFeedback.LinkInputSig(trilist.UShortInput[joinMap.TiltSpeed.JoinNumber]);
             ZoomSpeedFeedback.LinkInputSig(trilist.UShortInput[joinMap.ZoomSpeed.JoinNumber]);
 
-            trilist.SetBoolSigAction(joinMap.PanLeft.JoinNumber, sig =>
-            {
-                if (sig) PanLeft();
-                else PanStop();
-            });
-
-            trilist.SetBoolSigAction(joinMap.PanRight.JoinNumber, sig =>
-            {
-                if (sig) PanRight();
-                else PanStop();
-            });
-
-            trilist.SetBoolSigAction(joinMap.TiltUp.JoinNumber, sig =>
-            {
-                if (sig) TiltUp();
-                else TiltStop();
-            });
-
-            trilist.SetBoolSigAction(joinMap.TiltDown.JoinNumber, sig =>
-            {
-                if (sig) TiltDown();
-                else TiltStop();
-            });
-
-            trilist.SetBoolSigAction(joinMap.ZoomIn.JoinNumber, sig =>
-            {
-                if (sig) ZoomIn();
-                else ZoomStop();
-            });
-
-            trilist.SetBoolSigAction(joinMap.ZoomOut.JoinNumber, sig =>
-            {
-                if (sig) ZoomOut();
-                else ZoomStop();
-            });
+            trilist.SetBoolSigAction(joinMap.PanLeft.JoinNumber, sig => { if (sig) PanLeft(); else PanStop(); });
+            trilist.SetBoolSigAction(joinMap.PanRight.JoinNumber, sig => { if (sig) PanRight(); else PanStop(); });
+            trilist.SetBoolSigAction(joinMap.TiltUp.JoinNumber, sig => { if (sig) TiltUp(); else TiltStop(); });
+            trilist.SetBoolSigAction(joinMap.TiltDown.JoinNumber, sig => { if (sig) TiltDown(); else TiltStop(); });
+            trilist.SetBoolSigAction(joinMap.ZoomIn.JoinNumber, sig => { if (sig) ZoomIn(); else ZoomStop(); });
+            trilist.SetBoolSigAction(joinMap.ZoomOut.JoinNumber, sig => { if (sig) ZoomOut(); else ZoomStop(); });
 
             trilist.SetSigTrueAction(joinMap.PowerOn.JoinNumber, CameraOn);
             trilist.SetSigTrueAction(joinMap.PowerOff.JoinNumber, CameraOff);
@@ -462,7 +329,6 @@ namespace PanasonicCameraEpi
 
             foreach (var preset in PresetNamesFeedbacks)
             {
-                Debug.Console(2, "foreach: preset.Key: {0} preset.Value: {1}", preset.Key, preset.Value);
                 var presetNumber = preset.Key;
                 var nameJoin = joinMap.PresetNames.JoinNumber + presetNumber - 1;
                 preset.Value.LinkInputSig(trilist.StringInput[nameJoin]);
@@ -479,21 +345,13 @@ namespace PanasonicCameraEpi
             trilist.OnlineStatusChange += (o, a) =>
             {
                 if (!a.DeviceOnLine) return;
-
                 trilist.SetString(joinMap.DeviceName.JoinNumber, Name);
-                
             };
-        }        
-
-        #endregion Overrides of EssentialsBridgeableDevice
+        }
+        #endregion
 
         #region ICommunicationMonitor Members
-
-        public StatusMonitorBase CommunicationMonitor
-        {
-            get { return _monitor; }
-        }
-
+        public StatusMonitorBase CommunicationMonitor { get { return _monitor; } }
         #endregion
 
         public RoutingPortCollection<RoutingOutputPort> OutputPorts { get; private set; }

--- a/PanasonicCameraEpi/PanasonicResponseHandler.cs
+++ b/PanasonicCameraEpi/PanasonicResponseHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Crestron.SimplSharp.Net.Http;         
 using PepperDash.Essentials.Core;
 using PepperDash.Core;
 
@@ -12,47 +13,73 @@ namespace PanasonicCameraEpi
         public event EventHandler CameraPoweredOn;
         public event EventHandler CameraPoweredOff;
 
+        public sealed class BusyChangedEventArgs : EventArgs
+        {
+            public bool IsBusy { get; private set; }
+            public BusyChangedEventArgs(bool isBusy) { IsBusy = isBusy; }
+        }
+
+        public event EventHandler<BusyChangedEventArgs> BusyChanged;
+
+        private void RaiseBusy(bool busy)
+        {
+            var handler = BusyChanged;
+            if (handler != null)
+                handler(this, new BusyChangedEventArgs(busy));
+        }
+
         public PanasonicResponseHandler()
         {
-			ComsFb = new StringFeedback(() => _comsRx ?? string.Empty);
+            ComsFb = new StringFeedback(() => _comsRx ?? string.Empty);
         }
 
-        public void HandleResponseReceeved(object sender, GenericCommMethodReceiveTextArgs e)
+        public void HandleResponseReceived(object sender, GenericCommMethodReceiveTextArgs e)
         {
-			Debug.Console(2, "HandleResponseRecived Response:{0}\r", e.Text);
+            Debug.Console(2, "HandleResponseReceived (Serial) Body:{0}", e.Text);
         }
 
-		public void HandleResponseReceived(object sender, GenericHttpClientEventArgs e)
-		{
-			Debug.Console(1, "Received Response: {0} Response:{1}, Error: {2}\r", e.RequestPath, e.ResponseText, e.Error);
-			_comsRx = e.ResponseText;
-			ProcessComs(_comsRx);
-			ComsFb.FireUpdate();
-		}
+        public void HandleResponseReceived(object sender, GenericHttpClientEventArgs e)
+        {
+            var body = (e.ResponseText ?? string.Empty).Trim();
+
+            // Busy detection (Panasonic returns ER2 when busy)
+            if (body.StartsWith("ER2", StringComparison.OrdinalIgnoreCase))
+            {
+                RaiseBusy(true);
+                Debug.Console(1, "Device Busy: Path:{0} Body:{1} Error:{2}", e.RequestPath, body, e.Error);
+                _comsRx = body;
+                ComsFb.FireUpdate();
+                return;
+            }
+
+            // Clear busy only when the HTTP callback succeeded
+            if (e.Error == HTTP_CALLBACK_ERROR.COMPLETED)
+                RaiseBusy(false);
+
+            Debug.Console(1, "HTTP OK: Path:{0} Body:{1} Error:{2}", e.RequestPath, body, e.Error);
+            _comsRx = body;
+            ProcessComs(_comsRx);
+            ComsFb.FireUpdate();
+        }
 
         void ProcessComs(string coms)
         {
-            if (coms.Contains("p1")) 
+            if (coms.IndexOf("p1", StringComparison.OrdinalIgnoreCase) >= 0)
                 OnCameraPowerdOn();
-
-            else if (coms.Contains("p0")) 
+            else if (coms.IndexOf("p0", StringComparison.OrdinalIgnoreCase) >= 0)
                 OnCameraPowerdOff();
         }
 
         void OnCameraPowerdOn()
         {
             var handler = CameraPoweredOn;
-            if (handler == null) return;
-
-            handler.Invoke(this, EventArgs.Empty);
+            if (handler != null) handler(this, EventArgs.Empty);
         }
 
         void OnCameraPowerdOff()
         {
             var handler = CameraPoweredOff;
-            if (handler == null) return;
-
-            handler.Invoke(this, EventArgs.Empty);
+            if (handler != null) handler(this, EventArgs.Empty);
         }
     }
 }

--- a/PanasonicCameraEpi/PanasonicResponseHandler.cs
+++ b/PanasonicCameraEpi/PanasonicResponseHandler.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Crestron.SimplSharp.Net.Http;         
+using Crestron.SimplSharp.Net.Http;
 using PepperDash.Essentials.Core;
 using PepperDash.Core;
 


### PR DESCRIPTION
This pull request introduces improved handling of Panasonic camera busy states, refactors command and response wiring, and streamlines code throughout the Panasonic camera integration. The main focus is on preventing commands from being sent while the camera is busy, ensuring reliable communication pacing, and simplifying the code for maintainability.

**Busy State Handling and Command Queue Improvements**
* Added a busy state mechanism to `HttpCommandQueue`, wiring it to `PanasonicResponseHandler` to prevent commands from being sent when the camera reports itself as busy. Commands are skipped (not sent or re-enqueued) if the camera is busy, and thread pacing is maintained for stability. [[1]](diffhunk://#diff-13603bda04c99ef78591d6b9c679a5341bf4d06159caed1a9cc62a00d62d7e51R11-R31) [[2]](diffhunk://#diff-13603bda04c99ef78591d6b9c679a5341bf4d06159caed1a9cc62a00d62d7e51L31-R125)
* Implemented busy detection in `PanasonicResponseHandler`, raising events when the camera returns a busy response (`ER2`). The busy state is cleared only when a successful HTTP callback occurs.

**Code Refactoring and Simplification**
* Refactored property setters and command methods in `PanasonicCamera` to use concise one-line syntax, improving readability and maintainability. [[1]](diffhunk://#diff-43914e08bd063ac6e6013f86360fc19d0421c1014485d52cb288370039ed1b3fL29-R36) [[2]](diffhunk://#diff-43914e08bd063ac6e6013f86360fc19d0421c1014485d52cb288370039ed1b3fL180-R204)
* Streamlined event wiring and conditional logic in the camera constructor, fixing variable names and ensuring proper setup for command queue and response handling.

**API and Feedback Wiring**
* Simplified API linking and feedback wiring in `LinkToApi`, removing unnecessary comments and using concise lambda expressions for signal actions. [[1]](diffhunk://#diff-43914e08bd063ac6e6013f86360fc19d0421c1014485d52cb288370039ed1b3fL368-L401) [[2]](diffhunk://#diff-43914e08bd063ac6e6013f86360fc19d0421c1014485d52cb288370039ed1b3fL415-R316)

**General Clean-up**
* Removed unused code, redundant comments, and improved debug logging for clarity and consistency. [[1]](diffhunk://#diff-43914e08bd063ac6e6013f86360fc19d0421c1014485d52cb288370039ed1b3fL465) [[2]](diffhunk://#diff-43914e08bd063ac6e6013f86360fc19d0421c1014485d52cb288370039ed1b3fL343)

These changes collectively enhance the reliability of command dispatching to Panasonic cameras, especially under busy conditions, and make the codebase easier to maintain and extend.